### PR TITLE
Improve UX: better nav, tooltips, precise click jumps

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -17,7 +17,6 @@ jobs:
     outputs:
         tag: ${{ steps.git.outputs.tag }}
     strategy:
-      fail-fast: false
       matrix:
         config:
         - {
@@ -26,6 +25,13 @@ jobs:
             platform: windows_x64,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+          }
+        - {
+            name: "Windows Latest MSVC Arm64", artifact: "Windows-arm64",
+            os: windows-latest,
+            platform: windows_arm64,
+            cc: "cl", cxx: "cl",
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsamd64_arm64.bat",
           }
         - {
             name: "Ubuntu Latest GCC", artifact: "Linux-x64",
@@ -328,16 +334,16 @@ jobs:
         draft: false
         prerelease: false
 
-    # - name: Release on Extension Store
-    #   uses: qt-creator/deploy-qtc-plugin@v0.3
-    #   with:
-    #     api: ${{ secrets.EXTENSION_STORE_API_URL }}
-    #     token: ${{ secrets.EXTENSION_STORE_API_TOKEN }}
-    #     publish: true
-    #     spec: release/${{ env.PLUGIN_NAME }}.json
-    #     download-url-linux-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[0].browser_download_url }}
-    #     download-url-linux-x64: ${{ fromJSON(steps.create_release.outputs.assets)[1].browser_download_url }}
-    #     download-url-macos-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
-    #     download-url-macos-x64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
-    #     download-url-win-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[3].browser_download_url }}
-    #     download-url-win-x64: ${{ fromJSON(steps.create_release.outputs.assets)[4].browser_download_url }}
+    - name: Release on Extension Store
+      uses: qt-creator/deploy-qtc-plugin@v0.3
+      with:
+        api: ${{ secrets.EXTENSION_STORE_API_URL }}
+        token: ${{ secrets.EXTENSION_STORE_API_TOKEN }}
+        publish: true
+        spec: release/${{ env.PLUGIN_NAME }}.json
+        download-url-linux-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[0].browser_download_url }}
+        download-url-linux-x64: ${{ fromJSON(steps.create_release.outputs.assets)[1].browser_download_url }}
+        download-url-macos-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
+        download-url-macos-x64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
+        download-url-win-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[3].browser_download_url }}
+        download-url-win-x64: ${{ fromJSON(steps.create_release.outputs.assets)[4].browser_download_url }}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -5,7 +5,7 @@ on: [push]
 env:
   PLUGIN_NAME: MinimapPlugin
   QT_VERSION: 6.8.3
-  QT_CREATOR_VERSION: 16.0.1
+  QT_CREATOR_VERSION: 16.0.2
   MACOS_DEPLOYMENT_TARGET: "11.0"
   CMAKE_VERSION: "3.29.6"
   NINJA_VERSION: "1.12.1"
@@ -17,6 +17,7 @@ jobs:
     outputs:
         tag: ${{ steps.git.outputs.tag }}
     strategy:
+      fail-fast: false
       matrix:
         config:
         - {
@@ -25,13 +26,6 @@ jobs:
             platform: windows_x64,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-          }
-        - {
-            name: "Windows Latest MSVC Arm64", artifact: "Windows-arm64",
-            os: windows-latest,
-            platform: windows_arm64,
-            cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsamd64_arm64.bat",
           }
         - {
             name: "Ubuntu Latest GCC", artifact: "Linux-x64",
@@ -334,16 +328,16 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Release on Extension Store
-      uses: qt-creator/deploy-qtc-plugin@v0.3
-      with:
-        api: ${{ secrets.EXTENSION_STORE_API_URL }}
-        token: ${{ secrets.EXTENSION_STORE_API_TOKEN }}
-        publish: true
-        spec: release/${{ env.PLUGIN_NAME }}.json
-        download-url-linux-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[0].browser_download_url }}
-        download-url-linux-x64: ${{ fromJSON(steps.create_release.outputs.assets)[1].browser_download_url }}
-        download-url-macos-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
-        download-url-macos-x64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
-        download-url-win-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[3].browser_download_url }}
-        download-url-win-x64: ${{ fromJSON(steps.create_release.outputs.assets)[4].browser_download_url }}
+    # - name: Release on Extension Store
+    #   uses: qt-creator/deploy-qtc-plugin@v0.3
+    #   with:
+    #     api: ${{ secrets.EXTENSION_STORE_API_URL }}
+    #     token: ${{ secrets.EXTENSION_STORE_API_TOKEN }}
+    #     publish: true
+    #     spec: release/${{ env.PLUGIN_NAME }}.json
+    #     download-url-linux-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[0].browser_download_url }}
+    #     download-url-linux-x64: ${{ fromJSON(steps.create_release.outputs.assets)[1].browser_download_url }}
+    #     download-url-macos-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
+    #     download-url-macos-x64: ${{ fromJSON(steps.create_release.outputs.assets)[2].browser_download_url }}
+    #     download-url-win-arm64: ${{ fromJSON(steps.create_release.outputs.assets)[3].browser_download_url }}
+    #     download-url-win-x64: ${{ fromJSON(steps.create_release.outputs.assets)[4].browser_download_url }}

--- a/minimapconstants.h
+++ b/minimapconstants.h
@@ -33,5 +33,7 @@ const int MINIMAP_WIDTH_DEFAULT = 80;
 const int MINIMAP_EXTRA_AREA_WIDTH = 7;
 const int MINIMAP_MAX_LINE_COUNT_DEFAULT = 8000;
 const int MINIMAP_ALPHA_DEFAULT = 32;
+const bool MINIMAP_CENTER_ON_CLICK_DEFAULT = true;
+const bool MINIMAP_SHOW_LINE_TOOLTIP_DEFAULT = true;
 } // namespace Constants
 } // namespace Minimap

--- a/minimapsettings.cpp
+++ b/minimapsettings.cpp
@@ -48,6 +48,8 @@ const char enabledKey[] = "Enabled";
 const char widthKey[] = "Width";
 const char lineCountThresholdKey[] = "LineCountThresHold";
 const char alphaKey[] = "Alpha";
+const char centerOnClickKey[] = "CenterOnClick";
+const char showLineTooltipKey[] = "ShowLineTooltip";
 
 MinimapSettings *m_instance = 0;
 } // namespace
@@ -91,6 +93,14 @@ public:
         m_alpha->setToolTip(Tr::tr("The alpha value of the scrollbar slider"));
         m_alpha->setValue(m_instance->m_alpha);
         form->addRow(Tr::tr("Scrollbar slider alpha value:"), m_alpha);
+        m_centerOnClick = new QCheckBox(groupBox);
+        m_centerOnClick->setToolTip(Tr::tr("Center viewport on mouse position when clicking and dragging"));
+        m_centerOnClick->setChecked(m_instance->m_centerOnClick);
+        form->addRow(Tr::tr("Center on click:"), m_centerOnClick);
+        m_showLineTooltip = new QCheckBox(groupBox);
+        m_showLineTooltip->setToolTip(Tr::tr("Show line range tooltip when interacting with minimap"));
+        m_showLineTooltip->setChecked(m_instance->m_showLineTooltip);
+        form->addRow(Tr::tr("Show line tooltip:"), m_showLineTooltip);
         groupBox->setLayout(form);
         setLayout(layout);
         setEnabled(!m_textWrapping);
@@ -117,6 +127,14 @@ public:
             m_instance->setAlpha(m_alpha->value());
             save = true;
         }
+        if (m_centerOnClick->isChecked() != MinimapSettings::centerOnClick()) {
+            m_instance->setCenterOnClick(m_centerOnClick->isChecked());
+            save = true;
+        }
+        if (m_showLineTooltip->isChecked() != MinimapSettings::showLineTooltip()) {
+            m_instance->setShowLineTooltip(m_showLineTooltip->isChecked());
+            save = true;
+        }
         if (save) {
             Utils::storeToSettings(Utils::keyFromString(minimapPostFix),
                                    Core::ICore::settings(),
@@ -137,6 +155,8 @@ private:
     QSpinBox *m_width;
     QSpinBox *m_lineCountThresHold;
     QSpinBox *m_alpha;
+    QCheckBox *m_centerOnClick;
+    QCheckBox *m_showLineTooltip;
     bool m_textWrapping;
 };
 
@@ -158,6 +178,8 @@ MinimapSettings::MinimapSettings(QObject *parent)
     , m_width(Constants::MINIMAP_WIDTH_DEFAULT)
     , m_lineCountThreshold(Constants::MINIMAP_MAX_LINE_COUNT_DEFAULT)
     , m_alpha(Constants::MINIMAP_ALPHA_DEFAULT)
+    , m_centerOnClick(Constants::MINIMAP_CENTER_ON_CLICK_DEFAULT)
+    , m_showLineTooltip(Constants::MINIMAP_SHOW_LINE_TOOLTIP_DEFAULT)
 {
     QTC_ASSERT(!m_instance, return);
     m_instance = this;
@@ -182,6 +204,8 @@ Utils::Store MinimapSettings::toMap() const
     map.insert(widthKey, m_width);
     map.insert(lineCountThresholdKey, m_lineCountThreshold);
     map.insert(alphaKey, m_alpha);
+    map.insert(centerOnClickKey, m_centerOnClick);
+    map.insert(showLineTooltipKey, m_showLineTooltip);
     return map;
 }
 
@@ -191,6 +215,8 @@ void MinimapSettings::fromMap(const Utils::Store &map)
     m_width = map.value(widthKey, m_width).toInt();
     m_lineCountThreshold = map.value(lineCountThresholdKey, m_lineCountThreshold).toInt();
     m_alpha = map.value(alphaKey, m_alpha).toInt();
+    m_centerOnClick = map.value(centerOnClickKey, m_centerOnClick).toBool();
+    m_showLineTooltip = map.value(showLineTooltipKey, m_showLineTooltip).toBool();
 }
 
 bool MinimapSettings::enabled()
@@ -211,6 +237,16 @@ int MinimapSettings::lineCountThreshold()
 int MinimapSettings::alpha()
 {
     return m_instance->m_alpha;
+}
+
+bool MinimapSettings::centerOnClick()
+{
+    return m_instance->m_centerOnClick;
+}
+
+bool MinimapSettings::showLineTooltip()
+{
+    return m_instance->m_showLineTooltip;
 }
 
 void MinimapSettings::setEnabled(bool enabled)
@@ -242,6 +278,22 @@ void MinimapSettings::setAlpha(int alpha)
     if (m_alpha != alpha) {
         m_alpha = alpha;
         emit alphaChanged(alpha);
+    }
+}
+
+void MinimapSettings::setCenterOnClick(bool centerOnClick)
+{
+    if (m_centerOnClick != centerOnClick) {
+        m_centerOnClick = centerOnClick;
+        emit centerOnClickChanged(centerOnClick);
+    }
+}
+
+void MinimapSettings::setShowLineTooltip(bool showLineTooltip)
+{
+    if (m_showLineTooltip != showLineTooltip) {
+        m_showLineTooltip = showLineTooltip;
+        emit showLineTooltipChanged(showLineTooltip);
     }
 }
 } // namespace Internal

--- a/minimapsettings.h
+++ b/minimapsettings.h
@@ -44,12 +44,16 @@ public:
     static int width();
     static int lineCountThreshold();
     static int alpha();
+    static bool centerOnClick();
+    static bool showLineTooltip();
 
 signals:
     void enabledChanged(bool);
     void widthChanged(int);
     void lineCountThresholdChanged(int);
     void alphaChanged(int);
+    void centerOnClickChanged(bool);
+    void showLineTooltipChanged(bool);
 
 private:
     friend class MinimapSettingsPageWidget;
@@ -58,11 +62,15 @@ private:
     void setWidth(int width);
     void setLineCountThreshold(int lineCountThreshold);
     void setAlpha(int alpha);
+    void setCenterOnClick(bool centerOnClick);
+    void setShowLineTooltip(bool showLineTooltip);
 
     bool m_enabled;
     int m_width;
     int m_lineCountThreshold;
     int m_alpha;
+    bool m_centerOnClick;
+    bool m_showLineTooltip;
     MinimapSettingsPage *m_settingsPage;
 };
 } // namespace Internal


### PR DESCRIPTION
This PR adds details to the minimap making it much more enjoyable and useful. [Build available on my fork](https://github.com/Kidev/qt-creator-minimap/releases/tag/v16.0.2).

#### Changes
- Add option `Center on click` (default `ON`) that centers the viewport on mouse position when clicking and dragging on the minimap
- Add option `Show line tooltip` (default `ON`) that displays current visible line range on the cursor when clicking or dragging on the minimap
- Real-time smooth viewport following during mouse movement while holding click on the minimap
- Smart boundary handling: clicking in empty space below code in the minimap jumps to end of document
- Proper scaling calculation that respects actual code content height vs empty minimap space
- Backward compatibility: existing behavior preserved when features disabled (except the dragging that now works even when center on click is disabled)
- Change QtCreator version in CI to `16.0.2`

These changes transform the minimap from a basic scrollbar replacement into an interactive navigation tool that provides both intuitive control and useful visual feedback about your current position in the document.