### PR TITLE
Fix focus area render for QtCreator 17, make lines in tooltip pixel perfect

### DIFF
--- a/minimapsettings.cpp
+++ b/minimapsettings.cpp
@@ -24,8 +24,8 @@
 
 #include <coreplugin/icore.h>
 #include <extensionsystem/pluginmanager.h>
-#include <texteditor/texteditorconstants.h>
 #include <texteditor/displaysettings.h>
+#include <texteditor/texteditorconstants.h>
 #include <texteditor/texteditorsettings.h>
 #include <utils/qtcassert.h>
 #include <utils/store.h>
@@ -94,11 +94,13 @@ public:
         m_alpha->setValue(m_instance->m_alpha);
         form->addRow(Tr::tr("Scrollbar slider alpha value:"), m_alpha);
         m_centerOnClick = new QCheckBox(groupBox);
-        m_centerOnClick->setToolTip(Tr::tr("Center viewport on mouse position when clicking and dragging"));
+        m_centerOnClick->setToolTip(
+            Tr::tr("Center viewport on mouse position when clicking and dragging"));
         m_centerOnClick->setChecked(m_instance->m_centerOnClick);
         form->addRow(Tr::tr("Center on click:"), m_centerOnClick);
         m_showLineTooltip = new QCheckBox(groupBox);
-        m_showLineTooltip->setToolTip(Tr::tr("Show line range tooltip when interacting with minimap"));
+        m_showLineTooltip->setToolTip(
+            Tr::tr("Show line range tooltip when interacting with minimap"));
         m_showLineTooltip->setChecked(m_instance->m_showLineTooltip);
         form->addRow(Tr::tr("Show line tooltip:"), m_showLineTooltip);
         groupBox->setLayout(form);

--- a/minimapstyle.cpp
+++ b/minimapstyle.cpp
@@ -132,64 +132,64 @@ public:
             deferedUpdate();
             return false;
         }
-        
+
         // Handle mouse events on the scrollbar for center-on-click behavior and tooltip
         if (watched == m_editor->verticalScrollBar()) {
             if (event->type() == QEvent::MouseButtonPress) {
-                QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
+                QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
                 if (mouseEvent->button() == Qt::LeftButton) {
                     bool centerOnClick = MinimapSettings::centerOnClick();
                     bool showTooltip = MinimapSettings::showLineTooltip();
-                    
+
                     if (centerOnClick) {
                         m_isDragging = true;
                         m_lastMousePos = mouseEvent->pos();
                         centerViewportOnMousePosition(mouseEvent->pos());
                         m_editor->verticalScrollBar()->setMouseTracking(true);
                     }
-                    
+
                     if (showTooltip) {
                         showLineRangeTooltip(mouseEvent->globalPos());
                     }
-                    
+
                     return centerOnClick; // Only consume event if center-on-click is enabled
                 }
             } else if (event->type() == QEvent::MouseButtonRelease) {
-                QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
+                QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
                 if (mouseEvent->button() == Qt::LeftButton) {
                     bool wasHandled = false;
-                    
+
                     if (m_isDragging && MinimapSettings::centerOnClick()) {
                         m_isDragging = false;
                         m_editor->verticalScrollBar()->setMouseTracking(false);
                         wasHandled = true;
                     }
-                    
+
                     if (MinimapSettings::showLineTooltip()) {
                         QToolTip::hideText();
                     }
-                    
+
                     return wasHandled;
                 }
             } else if (event->type() == QEvent::MouseMove) {
-                QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
+                QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
                 bool wasHandled = false;
-                
+
                 if (m_isDragging && MinimapSettings::centerOnClick()) {
                     m_lastMousePos = mouseEvent->pos();
                     centerViewportOnMousePosition(mouseEvent->pos());
                     wasHandled = true;
                 }
-                
-                if (MinimapSettings::showLineTooltip() && 
+
+                if (MinimapSettings::showLineTooltip() &&
                     (m_isDragging || mouseEvent->buttons() & Qt::LeftButton)) {
                     showLineRangeTooltip(mouseEvent->globalPos());
                 }
-                
+
                 return wasHandled;
             }
         }
-        
+
         return false;
     }
 
@@ -226,9 +226,9 @@ private:
         QScrollBar *scrollbar = m_editor->verticalScrollBar();
         scrollbar->setProperty(Constants::MINIMAP_STYLE_OBJECT_PROPERTY,
                                QVariant::fromValue<QObject *>(this));
-        
+
         scrollbar->installEventFilter(this);
-        
+
         connect(m_editor->textDocument(),
                 &TextEditor::TextDocument::fontSettingsChanged,
                 this,
@@ -275,15 +275,15 @@ private:
     void centerViewportOnMousePosition(const QPoint &mousePos)
     {
         QScrollBar *scrollbar = m_editor->verticalScrollBar();
-        
+
         int mouseY = mousePos.y();
         int minimapHeight = scrollbar->height();
-        
+
         // Calculate the actual height that contains code content in the minimap
         // This matches the logic used in drawMinimap()
         qreal factor = m_factor;
         int actualContentHeight;
-        
+
         if (factor < 1.0) {
             // When zoomed out, content is scaled to fit
             actualContentHeight = qRound(m_lineCount * factor);
@@ -291,9 +291,9 @@ private:
             // When 1:1 or zoomed in, each line takes 1 pixel
             actualContentHeight = qMin(m_lineCount, minimapHeight);
         }
-        
+
         int targetLine;
-        
+
         // Check if mouse is within the actual code area
         if (mouseY <= actualContentHeight) {
             // Mouse is within code area - calculate proportionally
@@ -303,16 +303,16 @@ private:
             // Mouse is in empty area below code - go to end of document
             targetLine = m_lineCount;
         }
-        
+
         // Calculate the viewport height in lines
         int viewportHeight = m_editor->viewport()->height();
         int lineHeight = m_editor->fontMetrics().lineSpacing();
         int linesPerPage = viewportHeight / lineHeight;
-        
+
         // Center the viewport on the target line
         int centerLine = targetLine - (linesPerPage / 2);
         centerLine = qMax(1, qMin(centerLine, qMax(1, m_lineCount - linesPerPage + 1)));
-        
+
         // Convert back to scroll value (0-based for scroll position)
         int maxScrollValue = scrollbar->maximum();
         if (maxScrollValue > 0) {
@@ -333,7 +333,7 @@ private:
         QScrollBar *scrollbar = m_editor->verticalScrollBar();
         // Always keep event filter installed since we need it for tooltips too
         scrollbar->installEventFilter(this);
-        
+
         if (!MinimapSettings::centerOnClick()) {
             m_isDragging = false;
             scrollbar->setMouseTracking(false);
@@ -356,7 +356,7 @@ private:
         QPair<int, int> visibleRange = getVisibleLineRange();
         int s = visibleRange.first;
         int e = visibleRange.second;
-        
+
         QString tooltipText = QString("<center>%1<br>—<br>%2</center>").arg(s).arg(e);
         QToolTip::showText(globalPos, tooltipText, m_editor->verticalScrollBar());
     }
@@ -364,16 +364,16 @@ private:
     QPair<int, int> getVisibleLineRange() const
     {
         QScrollBar *scrollbar = m_editor->verticalScrollBar();
-        
+
         // Calculate lines per page based on viewport height
         int viewportHeight = m_editor->viewport()->height();
         int lineHeight = m_editor->fontMetrics().lineSpacing();
         int linesPerPage = viewportHeight / lineHeight;
-        
+
         // Get current scroll position
         int scrollValue = scrollbar->value();
         int maxScrollValue = scrollbar->maximum();
-        
+
         // Calculate first visible line (1-based for user display)
         int firstVisibleLine = 1;
         if (maxScrollValue > 0) {
@@ -381,10 +381,10 @@ private:
             int maxStartLine = qMax(1, m_lineCount - linesPerPage + 1);
             firstVisibleLine = qRound(scrollRatio * (maxStartLine - 1)) + 1;
         }
-        
+
         // Calculate last visible line
         int lastVisibleLine = qMin(firstVisibleLine + linesPerPage - 1, m_lineCount);
-        
+
         return QPair<int, int>(firstVisibleLine, lastVisibleLine);
     }
 
@@ -483,12 +483,12 @@ private:
         }
         realValue = qMax(0, realValue);
 
-        m_addPage = (realValue + viewPortLineCount < h) ?
-        QRect(0, realValue + viewPortLineCount, w, h - realValue - viewPortLineCount) :
-        QRect();
-        m_subPage = (realValue > 0) ?
-        QRect(0, 0, w, realValue) :
-        QRect();
+        m_addPage = (realValue + viewPortLineCount < h) ? QRect(0,
+                                                                realValue + viewPortLineCount,
+                                                                w,
+                                                                h - realValue - viewPortLineCount)
+                                                        : QRect();
+        m_subPage = (realValue > 0) ? QRect(0, 0, w, realValue) : QRect();
         m_slider = QRect(0, realValue, w, viewPortLineCount);
 
         scrollbar->update();
@@ -505,9 +505,7 @@ private:
     QPoint m_lastMousePos;
 };
 
-MinimapStyle::MinimapStyle(QStyle *style)
-    : QProxyStyle(style)
-{}
+MinimapStyle::MinimapStyle(QStyle *style) : QProxyStyle(style) {}
 
 void MinimapStyle::drawComplexControl(ComplexControl control,
                                       const QStyleOptionComplex *option,
@@ -544,10 +542,10 @@ QStyle::SubControl MinimapStyle::hitTestComplexControl(ComplexControl control,
                 if (MinimapSettings::centerOnClick()) {
                     return SC_ScrollBarGroove;
                 }
-                
+
                 SubControl sc = SC_None;
-                if (const QStyleOptionSlider *scrollbar
-                    = qstyleoption_cast<const QStyleOptionSlider *>(option)) {
+                if (const QStyleOptionSlider *scrollbar =
+                        qstyleoption_cast<const QStyleOptionSlider *>(option)) {
                     QRect r;
                     uint ctrl = SC_ScrollBarAddLine;
                     while (ctrl <= SC_ScrollBarGroove) {

--- a/minimapstyle.cpp
+++ b/minimapstyle.cpp
@@ -438,6 +438,13 @@ private:
     {
         QScrollBar *scrollbar = m_editor->verticalScrollBar();
 
+        if (m_lineCount <= 0) {
+            m_addPage = QRect();
+            m_subPage = QRect();
+            m_slider = QRect();
+            return;
+        }
+
         int viewportHeight = m_editor->viewport()->height();
         int lineHeight = m_editor->fontMetrics().lineSpacing();
         int actualLinesPerPage = qMax(1, viewportHeight / lineHeight);
@@ -453,13 +460,13 @@ private:
 
         int actualContentHeight;
         if (m_factor < 1.0) {
-            // When zoomed out, content is scaled to fit
-            actualContentHeight = qRound(m_lineCount * m_factor);
+            // When zoomed out: content is scaled, use the last drawn line position
+            actualContentHeight = qRound((m_lineCount - 1) * m_factor) + 1;
         } else {
-            // When 1:1 or zoomed in, each line takes 1 pixel
-            actualContentHeight = qMin(m_lineCount, h);
+            // When 1:1 or zoomed in: each line takes 1 pixel
+            actualContentHeight = m_lineCount;
         }
-        actualContentHeight = qMax(1, actualContentHeight);
+        actualContentHeight = qMin(actualContentHeight, h);
 
         int realValue = 0;
         if (max > min && actualContentHeight > viewPortLineCount) {


### PR DESCRIPTION
- The latest QtCreator version (17) changed `TextEditorWidget` (inside `texteditor.cpp`), that went from inheriting `QPlainTextEdit` to `Utils::PlainTextEdit`.  
This adapts the plugin so that the rendering of the focus area of the minimap is working again, by using the methods from `Utils::PlainTextEdit` (mainly `blockCount` instead of `size` to get the line count). Fixes #4. 

- The line numbers displayed in the tooltip on the minimap were slightly off, and it became worse with QtCreator 17.  
This changes the way the line numbers are computed and make it pixel perfect

- Fix some format errors